### PR TITLE
Rewrite socket implementation via coroutines.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,8 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
+    implementation("io.ktor:ktor-network:2.3.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
     implementation("com.github.uakihir0:bsky4j:0.5.2") {
         exclude("com.github.uakihir0", "JLogger")

--- a/src/main/kotlin/com/atty/Main.kt
+++ b/src/main/kotlin/com/atty/Main.kt
@@ -1,8 +1,9 @@
 package com.atty
 
+import io.ktor.network.sockets.*
+import kotlinx.coroutines.runBlocking
 import net.socialhub.http.HttpClientImpl
 import net.socialhub.logger.Logger
-import java.net.InetAddress
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
@@ -17,17 +18,21 @@ fun main(args: Array<String>) {
     Logger.getLogger(HttpClientImpl::class.java).logLevel = Logger.LogLevel.ERROR
 
     val server = TelnetServerImpl(port, logFile, object : ConnectionListener {
-        override fun onConnect(inetAddress: InetAddress) {
+        override fun onConnect(inetAddress: SocketAddress) {
             println("Received connection at: ${ZonedDateTime.now().format(timeFormatter)}")
         }
 
-        override fun onDisconnect(inetAddress: InetAddress, reason: DisconnectReason) {
+        override fun onDisconnect(inetAddress: SocketAddress, reason: DisconnectReason) {
             println("Lost connection at: ${ZonedDateTime.now().format(timeFormatter)} due to: $reason")
         }
     })
 
-    server.start()
-    while (server.isRunning()) {
-        // do nothing
+    runBlocking {
+        try {
+            server.start()
+            server.join()
+        } finally {
+            server.stop()
+        }
     }
 }

--- a/src/main/kotlin/com/atty/scopes/BaseLoggedInScope.kt
+++ b/src/main/kotlin/com/atty/scopes/BaseLoggedInScope.kt
@@ -1,30 +1,29 @@
 package com.atty.scopes
 
-import com.atty.DisconnectReason
+import com.atty.DisconnectHandler
 import com.atty.libs.BlueskyReadClient
-import java.net.Socket
+import io.ktor.network.sockets.*
 
 abstract class BaseLoggedInScope(
     val blueskyClient: BlueskyReadClient,
-    clientSocket: Socket,
+    connection: Connection,
     val isCommodore: Boolean,
-    threadProvider: () -> Thread,
-    disconnectHandler: (DisconnectReason) -> Unit,
-) : BaseScope(clientSocket, threadProvider, disconnectHandler) {
+    disconnectHandler: DisconnectHandler,
+) : BaseScope(connection, disconnectHandler) {
 
-    fun waitForStringInput(): String {
+    suspend fun waitForStringInput(): String {
         return waitForStringInput(isCommodore)
     }
 
-    fun writeUi(text: String) {
+    suspend fun writeUi(text: String) {
         writeUi(text, isCommodore)
     }
 
-    fun writeAppText(text: String) {
+    suspend fun writeAppText(text: String) {
         writeAppText(text, isCommodore)
     }
 
-    fun writePrompt(text: String = "") {
+    suspend fun writePrompt(text: String = "") {
         writePrompt(text, isCommodore)
     }
 }

--- a/src/main/kotlin/com/atty/scopes/CreateLikeScope.kt
+++ b/src/main/kotlin/com/atty/scopes/CreateLikeScope.kt
@@ -1,18 +1,17 @@
 package com.atty.scopes
 
-import com.atty.DisconnectReason
+import com.atty.DisconnectHandler
 import com.atty.libs.BlueskyReadClient
 import com.atty.models.GenericPostAttributes
-import java.net.Socket
+import io.ktor.network.sockets.*
 
 class CreateLikeScope (
     val genericPostAttributes: GenericPostAttributes,
     blueskyClient: BlueskyReadClient,
-    clientSocket: Socket,
-    disconnectHandler: (DisconnectReason) -> Unit,
-    isCommodore: Boolean,
-    threadProvider: () -> Thread) : BaseLoggedInScope(blueskyClient, clientSocket, isCommodore, threadProvider, disconnectHandler) {
-    fun showLiked() {
+    connection: Connection,
+    disconnectHandler: DisconnectHandler,
+    isCommodore: Boolean) : BaseLoggedInScope(blueskyClient, connection, isCommodore, disconnectHandler) {
+    suspend fun showLiked() {
         writeUi("Liked")
     }
 }

--- a/src/main/kotlin/com/atty/scopes/CreatePostScope.kt
+++ b/src/main/kotlin/com/atty/scopes/CreatePostScope.kt
@@ -1,22 +1,22 @@
 package com.atty.scopes
 
-import com.atty.DisconnectReason
+import com.atty.DisconnectHandler
 import com.atty.libs.BlueskyReadClient
 import com.atty.models.GenericPostAttributes
 import com.atty.models.PendingPost
-import java.net.Socket
+import io.ktor.network.sockets.*
+import io.ktor.utils.io.*
 
 class CreatePostScope(
     val inReplyTo: GenericPostAttributes?,
     blueskyClient: BlueskyReadClient,
-    clientSocket: Socket,
-    disconnectHandler: (DisconnectReason) -> Unit,
-    isCommodore: Boolean,
-    threadProvider: () -> Thread) : BaseLoggedInScope(blueskyClient, clientSocket, isCommodore, threadProvider, disconnectHandler) {
+    connection: Connection,
+    disconnectHandler: DisconnectHandler,
+    isCommodore: Boolean) : BaseLoggedInScope(blueskyClient, connection, isCommodore, disconnectHandler) {
 
-    fun getPost(): PendingPost {
-        socket.getOutputStream().write(
-            "\n>".toByteArray()
+    suspend fun getPost(): PendingPost {
+        connection.output.writeStringUtf8(
+            "\n>"
         )
 
         var inputString = waitForStringInput()
@@ -30,7 +30,7 @@ class CreatePostScope(
         return PendingPost(inputString, inReplyTo)
     }
 
-    fun showPosted() {
+    suspend fun showPosted() {
         writeUi(
             "Sent Post!"
         )

--- a/src/main/kotlin/com/atty/scopes/CreateQuoteScope.kt
+++ b/src/main/kotlin/com/atty/scopes/CreateQuoteScope.kt
@@ -1,22 +1,22 @@
 package com.atty.scopes
 
-import com.atty.DisconnectReason
+import com.atty.DisconnectHandler
 import com.atty.libs.BlueskyReadClient
 import com.atty.models.GenericPostAttributes
 import com.atty.models.PendingPost
-import java.net.Socket
+import io.ktor.network.sockets.*
+import io.ktor.utils.io.*
 
 class CreateQuoteScope(
     val genericPostAttributes: GenericPostAttributes,
     blueskyClient: BlueskyReadClient,
-    clientSocket: Socket,
-    disconnectHandler: (DisconnectReason) -> Unit,
-    isCommodore: Boolean,
-    threadProvider: () -> Thread) : BaseLoggedInScope(blueskyClient, clientSocket, isCommodore, threadProvider, disconnectHandler) {
+    connection: Connection,
+    disconnectHandler: DisconnectHandler,
+    isCommodore: Boolean) : BaseLoggedInScope(blueskyClient, connection, isCommodore, disconnectHandler) {
 
-    fun getPost(): PendingPost {
-        socket.getOutputStream().write(
-            "\n>".toByteArray()
+    suspend fun getPost(): PendingPost {
+        connection.output.writeStringUtf8(
+            "\n>"
         )
 
         var inputString = waitForStringInput()
@@ -30,7 +30,7 @@ class CreateQuoteScope(
         return PendingPost(inputString, null, genericPostAttributes)
     }
 
-    fun showQuoted() {
+    suspend fun showQuoted() {
         writeUi("Quoted")
     }
 }

--- a/src/main/kotlin/com/atty/scopes/CreateRepostScope.kt
+++ b/src/main/kotlin/com/atty/scopes/CreateRepostScope.kt
@@ -1,18 +1,17 @@
 package com.atty.scopes
 
-import com.atty.DisconnectReason
+import com.atty.DisconnectHandler
 import com.atty.libs.BlueskyReadClient
 import com.atty.models.GenericPostAttributes
-import java.net.Socket
+import io.ktor.network.sockets.*
 
 class CreateRepostScope(
     val genericPostAttributes: GenericPostAttributes,
     blueskyClient: BlueskyReadClient,
-    clientSocket: Socket,
-    disconnectHandler: (DisconnectReason) -> Unit,
-    isCommodore: Boolean,
-    threadProvider: () -> Thread) : BaseLoggedInScope(blueskyClient, clientSocket, isCommodore, threadProvider, disconnectHandler) {
-        fun showReposted() {
+    connection: Connection,
+    disconnectHandler: DisconnectHandler,
+    isCommodore: Boolean) : BaseLoggedInScope(blueskyClient, connection, isCommodore, disconnectHandler) {
+        suspend fun showReposted() {
             writeUi("Reposted")
         }
     }

--- a/src/main/kotlin/com/atty/scopes/HomeTimelineScope.kt
+++ b/src/main/kotlin/com/atty/scopes/HomeTimelineScope.kt
@@ -2,20 +2,19 @@ package com.atty.scopes
 
 import bsky4j.model.bsky.feed.FeedDefsFeedViewPost
 import bsky4j.model.bsky.feed.FeedPost
-import com.atty.DisconnectReason
+import com.atty.DisconnectHandler
 import com.atty.libs.BlueskyReadClient
 import com.atty.models.GenericPostAttributes
 import com.atty.models.getAuthorAttributes
-import java.net.Socket
+import io.ktor.network.sockets.*
 
 class HomeTimelineScope (
     val feed: List<FeedDefsFeedViewPost>,
     blueskyClient: BlueskyReadClient,
-    socket: Socket,
+    connection: Connection,
     isCommodore: Boolean,
-    threadProvider: () -> Thread,
-    disconnectHandler: (DisconnectReason) -> Unit) : BaseLoggedInScope(blueskyClient, socket, isCommodore, threadProvider, disconnectHandler) {
-    fun forEachPost(block: PostScope.() -> Unit) {
+    disconnectHandler: DisconnectHandler) : BaseLoggedInScope(blueskyClient, connection, isCommodore, disconnectHandler) {
+    suspend fun forEachPost(block: suspend PostScope.() -> Unit) {
         feed.forEach {
             if (it.post.record is FeedPost) {
                 val feedPost = it.post.record as FeedPost
@@ -24,9 +23,9 @@ class HomeTimelineScope (
                     feedPost,
                     GenericPostAttributes(feedPost, it.post.uri, it.post.cid),
                     blueskyClient,
-                    socket,
-                    isCommodore, threadProvider, disconnectHandler
-                ).apply(block)
+                    connection,
+                    isCommodore, disconnectHandler
+                ).apply { block() }
             }
         }
     }


### PR DESCRIPTION
Ktor provides a socket implementation that lets you call a suspending method to `accept()` an incoming socket connection. The result of this is that instead of using a `Thread` pool to manage incoming requests, requests are processed in the `Dispatchers.IO` coroutine pool.

I don't know if this is something you're interesting in accepting but I thought this project was super neat and when I saw it I totally nerd sniped myself into trying this out 😄 Keep up the awesome stuff!